### PR TITLE
Add YAML output format

### DIFF
--- a/bin/whenever
+++ b/bin/whenever
@@ -38,6 +38,9 @@ OptionParser.new do |opts|
   opts.on('-x', '--crontab-command [command]', 'Default: crontab') do |crontab_command|
     options[:crontab_command] = crontab_command if crontab_command
   end
+  opts.on('-o', '--format [format]', 'Default: cron') do |format|
+    options[:output_format] = format.to_sym if format
+  end
   opts.on('-v', '--version') { puts "Whenever v#{Whenever::VERSION}"; exit(0) }
 end.parse!
 

--- a/lib/whenever.rb
+++ b/lib/whenever.rb
@@ -6,6 +6,7 @@ require 'whenever/command_line'
 require 'whenever/cron'
 require 'whenever/output_redirection'
 require 'whenever/os'
+require 'whenever/yaml'
 
 module Whenever
   def self.cron(options)

--- a/lib/whenever/job.rb
+++ b/lib/whenever/job.rb
@@ -27,6 +27,8 @@ module Whenever
       roles.empty? || roles.include?(role)
     end
 
+    attr_reader :options
+
   protected
 
     def process_template(template, options)

--- a/lib/whenever/job_list.rb
+++ b/lib/whenever/job_list.rb
@@ -9,6 +9,9 @@ module Whenever
         options = { :string => options }
       end
 
+      # One of [:crontab, :yaml]
+      @output_format = options.fetch(:output_format, :crontab)
+
       pre_set(options[:set])
 
       @roles = options[:roles] || []
@@ -72,7 +75,12 @@ module Whenever
     end
 
     def generate_cron_output
-      [environment_variables, cron_jobs].compact.join
+      case @output_format
+      when :yaml
+        Whenever::Output::Yaml.output(@jobs)
+      else
+        [environment_variables, cron_jobs].compact.join
+      end
     end
 
   private

--- a/lib/whenever/yaml.rb
+++ b/lib/whenever/yaml.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+module Whenever
+  module Output
+    # Generates cron config in an extended YAML format:
+    # ---
+    # version: 1
+    # crons:
+    #   - frequency: "1,2 * * * *"
+    #     name: Jobs::SomeJob
+    #     timezone: UTC
+    #     command: bin/rails runner 'JobRunner::Runner.new(Jobs::SomeJob).run'
+    #     team: core-infrastructure
+    #     retryable: true
+    class Yaml
+      # TODO: validate timezone
+      def self.output_job(time, job)
+        {
+          name: job.options[:job_name],
+          command: job.output,
+          frequency: Whenever::Output::Cron.new(time).time_in_cron_syntax,
+          timezone: job.options.fetch(:timezone, 'UTC'),
+          team: job.options.fetch(:team, :unknown).to_s,
+          retryable: job.options.fetch(:retryable, false)
+        }.transform_keys(&:to_s)
+      end
+
+      # @param [Hash<time, Array<Job>>]
+      def self.output(jobs_per_time)
+        crons = jobs_per_time[:default_mailto].flat_map do |time, jobs|
+          jobs.map { |job| output_job(time, job) }
+        end
+
+        YAML.dump("version" => 1, "crons" => crons)
+      end
+    end
+  end
+end

--- a/test/functional/output_yaml_test.rb
+++ b/test/functional/output_yaml_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class OutputYaml < Whenever::TestCase
+  test "with output_format => yaml" do
+    output = Whenever.cron :output_format => :yaml, :string => \
+    <<-file
+      every 2.hours do
+        command "blahblah"
+      end
+    file
+
+    assert_equal(
+      {
+        "version" => 1,
+        "crons" => [
+          {
+            "name" => nil,
+            "command" => "/bin/bash -l -c 'blahblah'",
+            "timezone" => "UTC",
+            "team" => "unknown",
+            "retryable" => false,
+            "frequency" => two_hours
+          }
+        ]
+      },
+      YAML.load(output)
+    )
+  end
+
+  test "specifying job_name, timezone, team and retryable" do
+    output = Whenever.cron :output_format => :yaml, :string => \
+    <<-file
+      every 2.hours do
+        command "launch-rocket",
+                job_name: "launch-rocket",
+                timezone: "BST",
+                team: "core-infrastructure",
+                retryable: true
+      end
+    file
+
+    assert_equal(
+      {
+        "version" => 1,
+        "crons" => [
+          {
+            "name" => "launch-rocket",
+            "command" => "/bin/bash -l -c 'launch-rocket'",
+            "timezone" => "BST",
+            "team" => "core-infrastructure",
+            "retryable" => true,
+            "frequency" => two_hours
+          }
+        ]
+      },
+      YAML.load(output)
+    )
+  end
+end

--- a/whenever.gemspec
+++ b/whenever.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "mocha", ">= 0.9.5"
   s.add_development_dependency "minitest"
   s.add_development_dependency "appraisal"
+  s.add_development_dependency "pry"
 end


### PR DESCRIPTION
This format is designed to integrate better with Kubernetes' cronjob
system, and provides some extra fields that GC have found useful.